### PR TITLE
FEAT - Resume section

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import Header from "./components/Header/Header";
 import Background from "./components/Backgroung/Background";
 import Skills from "./components/Skills/Skills";
+import Resume from "./components/Resume/Resume";
 
 import "./App.scss";
 
@@ -10,6 +11,7 @@ function App() {
       <Header />
       <Background />
       <Skills />
+      <Resume />
     </>
   );
 }

--- a/src/components/Motion/Motion.tsx
+++ b/src/components/Motion/Motion.tsx
@@ -8,13 +8,15 @@ import { fadeIn } from "../../utils/fadeIn";
 interface MotionProps {
   children: ReactNode;
   className: string;
-  type: "div" | "header" | "section";
+  type?: "div" | "header" | "section";
+  viewport?: number;
 }
 
 const Motion: React.FC<MotionProps> = ({
   children,
   className,
   type = "div",
+  viewport = 0.3,
 }) => {
   const isMobile = useMediaQuery({ maxWidth: 480 });
   const MotionTag = motion[type];
@@ -25,7 +27,7 @@ const Motion: React.FC<MotionProps> = ({
       variants={fadeIn(isMobile ? "up" : "right", 0.5)}
       initial="hidden"
       whileInView={"show"}
-      viewport={{ once: false, amount: 0.3 }}
+      viewport={{ once: false, amount: viewport }}
     >
       {children}
     </MotionTag>

--- a/src/components/Resume/Resume.scss
+++ b/src/components/Resume/Resume.scss
@@ -1,0 +1,23 @@
+.resume {
+  font-size: 1.5rem;
+  padding: 6rem 0;
+
+  a {
+    @include flex-center;
+    gap: 1rem;
+
+    &:hover .resume__arrow_icon {
+      animation: bounce 1s infinite;
+    }
+  }
+
+  @keyframes bounce {
+    0%,
+    100% {
+      transform: translateY(0);
+    }
+    50% {
+      transform: translateY(-10px);
+    }
+  }
+}

--- a/src/components/Resume/Resume.tsx
+++ b/src/components/Resume/Resume.tsx
@@ -1,0 +1,15 @@
+import { TfiDownload } from "react-icons/tfi";
+import Motion from "../Motion/Motion";
+
+const Resume = () => {
+  return (
+    <Motion className="resume" viewport={0.1}>
+      <a href="https://storage.cloud.google.com/maksim_lukianneko_cv/Maksim%20Lukianenko_CV.pdf">
+        View My Resume
+        <TfiDownload className="resume__arrow_icon" />
+      </a>
+    </Motion>
+  );
+};
+
+export default Resume;

--- a/src/components/Skills/Skills.tsx
+++ b/src/components/Skills/Skills.tsx
@@ -1,4 +1,5 @@
 import Motion from "../Motion/Motion";
+import Resume from "../Resume/Resume";
 import SkillsView from "./SkillsView";
 
 const Skills = () => {

--- a/src/components/Skills/SkillsView.scss
+++ b/src/components/Skills/SkillsView.scss
@@ -5,6 +5,7 @@
       font-weight: 500;
       margin-bottom: 1rem;
       text-align: left;
+      min-width: 98px;
     }
 
     li {

--- a/src/components/Skills/SkillsView.tsx
+++ b/src/components/Skills/SkillsView.tsx
@@ -1,13 +1,12 @@
 import { SimpleGrid, Badge, Tag } from "@chakra-ui/react";
 import { useMediaQuery } from "react-responsive";
+import { FaStar } from "react-icons/fa";
 
 const SkillsView = () => {
   const isMobile = useMediaQuery({ maxWidth: 480 });
-  const tagSize = "lg";
   const badgeFontSize = "10px";
   const badgeMarginLeft = 1;
-  const colorScheme = "gray";
-  const tagVariant = undefined;
+
   return (
     <>
       <h1 className="section__title">Skills</h1>
@@ -22,8 +21,8 @@ const SkillsView = () => {
             <li>JavaScript</li>
             <li>
               TypeScript{" "}
-              <Badge colorScheme="orange" fontSize="0.7rem">
-                Fav
+              <Badge colorScheme="orange" fontSize="0.9rem">
+                <FaStar />
               </Badge>
             </li>
             <li>HTML</li>

--- a/src/styles/_components.scss
+++ b/src/styles/_components.scss
@@ -1,3 +1,4 @@
 @import "../components/Header/HeaderView.scss";
 @import "../components/Backgroung/BackgroundView.scss";
 @import "../components/Skills/SkillsView.scss";
+@import "../components/Resume/Resume.scss";


### PR DESCRIPTION
feat(App.tsx): add Resume component to App to display resume section on the page

feat(Motion.tsx): add optional viewport prop to Motion component to control the amount of visibility required for animation
feat(Resume.tsx): create Resume component to display a link to download the resume
feat(Skills.tsx): import Resume component to Skills component to display resume section in Skills section
feat(SkillsView.tsx): add star icon to TypeScript badge in SkillsView component to indicate favorite skill
feat(_components.scss): import Resume.scss to include styles for Resume component